### PR TITLE
Possible prevnext nav style, closes #8

### DIFF
--- a/_assets/scss/_styles.scss
+++ b/_assets/scss/_styles.scss
@@ -524,7 +524,8 @@ Page content
     }
 }
 
-.header-more {
+.header-more,
+.prevnext-nav {
     align-items: baseline;
     display: flex;
     justify-content: space-between;

--- a/views/partials/pagination.twig
+++ b/views/partials/pagination.twig
@@ -1,7 +1,9 @@
-<nav class="prevnext-nav">
-    {% if posts.pagination.prev %}
-        <a href="{{posts.pagination.prev.link}}" class="prev {{posts.pagination.prev.link|length ? '' : 'squelch'}}">&larr; Previous</a>
-    {% endif %} {% if posts.pagination.next %}
-        <a href="{{posts.pagination.next.link}}" class="next {{posts.pagination.next.link|length ? '' : 'squelch'}}">Next &rarr;</a>
-    {% endif %}
+<nav class="l-sole">
+    <div class="group prevnext-nav">
+        {% if posts.pagination.prev %}
+            <a href="{{posts.pagination.prev.link}}" class="prev {{posts.pagination.prev.link|length ? '' : 'squelch'}}">&larr; Previous</a>
+        {% endif %} {% if posts.pagination.next %}
+            <a href="{{posts.pagination.next.link}}" class="next {{posts.pagination.next.link|length ? '' : 'squelch'}}">Next &rarr;</a>
+        {% endif %}
+    </div>
 </nav>


### PR DESCRIPTION
Hi @beep! I sifted through your lovely style sheet and located a pattern that would work for some layout on the previous/next pagination buttons ([here](http://kmg-stage.bondartscience.com/articles/page/2/) for reference) – they should look like this:

<img width="907" alt="screen shot 2018-05-03 at 8 33 15 pm" src="https://user-images.githubusercontent.com/445861/39612145-c1cf8030-4f11-11e8-9ef8-05ae3ff5382e.png">

Unfortunately I was having some issues building the Sass – can you build and either push to this branch (I believe I gave you collab access if you want to work directly on this repo) or open up a PR with the compiled files + any changes to the `prevnext` situation? 

Also relevant – I added a `hed-section-sub` for "Page 1 of X" to the template above the "Articles By Karen". See if that needs any adjustments as well (code is already in master). 

Thank youu!